### PR TITLE
Fix io-audio JACK Driver Playback with Fixed Point

### DIFF
--- a/qnx/ioaudio/ioaudio_driver.c
+++ b/qnx/ioaudio/ioaudio_driver.c
@@ -444,7 +444,7 @@ int jack_process(
                     sample_t* dest = (sample_t*)jack_buf[v];
                     size_t amt = min( read_buf[0].len,
                                       remaining );
-                    for( s = 0; s < amt; s += sizeof(sample_t) )
+                    for( s = 0; s < amt; ++s )
                         {
                         dest[s] = ( (sample_t)src[s] ) * ( (sample_t)1.0 )
                             / ( (sample_t)INT_MAX );
@@ -456,7 +456,7 @@ int jack_process(
                         dest += amt;
                         amt = min( read_buf[1].len,
                                    remaining );
-                        for( s = 0; s < amt; s += sizeof(sample_t) )
+                        for( s = 0; s < amt; ++s )
                             {
                             dest[s] = ( (sample_t)src[s] ) * ( (sample_t)1.0 )
                                 / ( (sample_t)INT_MAX );


### PR DESCRIPTION
When playing a fixed-point wave file, the JACK io-audio driver was
only playing every fourth sample.  This was due to a math error in the
io-audio driver code that was incrementing by the sizeof a sample
rather than just incrementing by 1.
