### PR TITLE
Fix io-audio JACK Driver Port Name Convention

### DIFF
--- a/qnx/ioaudio/ioaudio_driver.c
+++ b/qnx/ioaudio/ioaudio_driver.c
@@ -17,7 +17,7 @@
 
 #include <sys/asound.h>
 
-static const char* PORTNAME_FMT = "playback_%d";
+static const char* PORTNAME_FMT = "capture_%d";
 typedef jack_default_audio_sample_t sample_t;
 
 struct subchn


### PR DESCRIPTION
Generally, JACK input ports are called "capture" and a number, while
output ports are called "playback".  The io-audio JACK driver for QNX
looks like an io-audio playback device, but to JACK, it looks like a
capture device.  So I have updated the driver to call its ports
"capture" rather than "playback".
