### PR TITLE
Add systemd support

### DIFF
--- a/common/Jackdmp.cpp
+++ b/common/Jackdmp.cpp
@@ -50,7 +50,7 @@ are "hard-coded" in the source. A much better approach would be to use the contr
 - get available drivers and their possible parameters, then prepare to parse them.
 */
 
-#ifdef __APPLE__
+#if defined(__APPLE__)
 #include <CoreFoundation/CFNotificationCenter.h>
 #include <CoreFoundation/CoreFoundation.h>
 
@@ -76,6 +76,20 @@ static void notify_server_stop(const char* server_name)
             NULL,
             kCFNotificationDeliverImmediately | kCFNotificationPostToAllSessions);
     CFRelease(ref1);
+}
+
+#elif defined(JACK_SYSTEMD)
+
+#include <systemd/sd-daemon.h>
+
+static void notify_server_start(const char* server_name)
+{
+    sd_notify(0, "READY=1");
+}
+
+static void notify_server_stop(const char* server_name)
+{
+    sd_notify(0, "STOPPING=1");
 }
 
 #else

--- a/linux/wscript
+++ b/linux/wscript
@@ -35,6 +35,8 @@ def build(bld):
         else:
             jackd.use += ['PTHREAD', 'DL', 'RT', 'M', 'STDC++']
         jackd.target = 'jackd'
+        if bld.env['BUILD_SYSTEMD_SUPPORT']:
+            jackd.use += ['LIBSYSTEMD']
 
     create_jack_driver_obj(bld, 'dummy', '../common/JackDummyDriver.cpp')
 

--- a/wscript
+++ b/wscript
@@ -439,6 +439,8 @@ def options(opt):
     readline.set_check_hook(check_for_readline, check_for_readline_error)
 
     ioaudio = add_auto_option(opt, 'ioaudio', help='Enable io-audio driver', conf_dest='BUILD_DRIVER_IOAUDIO')
+    systemd = add_auto_option(opt, 'systemd', help='Enable systemd support', conf_dest='BUILD_SYSTEMD_SUPPORT')
+    systemd.add_package('libsystemd')
 
     # dbus options
     opt.recurse('dbus')
@@ -601,6 +603,8 @@ def configure(conf):
         conf.define('JACK_DBUS', 1)
     if conf.env['BUILD_WITH_PROFILE'] == True:
         conf.define('JACK_MONITOR', 1)
+    if conf.env['BUILD_SYSTEMD_SUPPORT'] == True:
+        conf.define('JACK_SYSTEMD', 1)
     conf.write_config_header('config.h', remove=False)
 
     svnrev = None


### PR DESCRIPTION
This patch adds optional support for systemd, by adding use of the
sd_notify() function to allow jackd to report when the daemon has
started and stopped.  This is similar to the Apple notification
support which is already present.
