### PR TITLE
Add support for QCC compiler

### DIFF
--- a/common/JackServerGlobals.cpp
+++ b/common/JackServerGlobals.cpp
@@ -200,15 +200,15 @@ bool JackServerGlobals::Init()
             switch (opt) {
 
                 case 'c':
-                    if (tolower (optarg[0]) == 'h') {
+                    if (std::tolower (optarg[0]) == 'h') {
                         clock_source = JACK_TIMER_HPET;
-                    } else if (tolower (optarg[0]) == 'c') {
+                    } else if (std::tolower (optarg[0]) == 'c') {
                         /* For backwards compatibility with scripts, allow
                          * the user to request the cycle clock on the
                          * command line, but use the system clock instead
                          */
                         clock_source = JACK_TIMER_SYSTEM_CLOCK;
-                    } else if (tolower (optarg[0]) == 's') {
+                    } else if (std::tolower (optarg[0]) == 's') {
                         clock_source = JACK_TIMER_SYSTEM_CLOCK;
                     } else {
                         jack_error("unknown option character %c", optopt);

--- a/dbus/wscript
+++ b/dbus/wscript
@@ -69,7 +69,7 @@ def build(bld):
     if bld.env['IS_MACOSX']:
         obj.use += ['PTHREAD', 'DL', 'DBUS-1', 'EXPAT']
     if bld.env['IS_QNX']:
-        obj.use += ['PTHREAD', 'DL', 'DBUS-1', 'EXPAT', 'STDC++']
+        obj.use += ['PTHREAD', 'DL', 'DBUS-1', 'EXPAT']
     obj.target = 'jackdbus'
 
     # process org.jackaudio.service.in -> org.jackaudio.service

--- a/example-clients/wscript
+++ b/example-clients/wscript
@@ -56,18 +56,22 @@ def build(bld):
     for example_program, example_program_source in list(example_programs.items()):
         if example_program == 'jack_server_control':
             use = ['serverlib', 'STDC++']
+            features = 'cxx cxxprogram'
         elif example_program == 'jack_net_slave':
             if not bld.env['BUILD_NETLIB']:
                 continue
             use = ['netlib']
+            features = 'c cprogram'
         elif example_program == 'jack_net_master':
             if not bld.env['BUILD_NETLIB']:
                 continue
             use = ['netlib']
+            features = 'c cprogram'
         else:
             use = ['clientlib']
+            features = 'c cprogram'
 
-        prog = bld(features='c cprogram')
+        prog = bld(features=features)
         prog.includes = os_incdir + ['../common/jack', '../common']
         prog.source = example_program_source
         prog.use = use

--- a/posix/JackPosixServerLaunch.cpp
+++ b/posix/JackPosixServerLaunch.cpp
@@ -124,7 +124,7 @@ static void start_server_classic_aux(const char* server_name)
 
     if (!good) {
         command = (char*)(JACK_LOCATION "/jackd");
-        strncpy(arguments, JACK_LOCATION "/jackd -T -d "JACK_DEFAULT_DRIVER, 255);
+        strncpy(arguments, JACK_LOCATION "/jackd -T -d " JACK_DEFAULT_DRIVER, 255);
     } else {
         result = strcspn(arguments, " ");
         command = (char*)malloc(result + 1);

--- a/tests/external_metro.cpp
+++ b/tests/external_metro.cpp
@@ -19,6 +19,8 @@
 #include "external_metro.h"
 #include <cstdio>
 
+using namespace std;
+
 typedef jack_default_audio_sample_t sample_t;
 
 const double PI = 3.14;

--- a/tests/wscript
+++ b/tests/wscript
@@ -22,6 +22,7 @@ def build(bld):
 	        prog.includes = ['..','../linux', '../posix', '../common/jack', '../common']
         if bld.env['IS_QNX']:
 	        prog.includes = ['..','../qnx', '../posix', '../common/jack', '../common']
+	        prog.uselib = 'M'
         if bld.env['IS_SUN']:
 	        prog.includes = ['..','../solaris', '../posix', '../common/jack', '../common']
         prog.source = test_program_sources

--- a/waflib/Tools/qcc.py
+++ b/waflib/Tools/qcc.py
@@ -1,0 +1,92 @@
+#!/usr/bin/env python
+
+import os
+import tempfile
+import re
+
+from waflib import Logs, Task, Utils
+from waflib.Tools import ar
+from waflib.Tools import c_config
+
+def to_list(xx):
+    if isinstance(xx, list):
+        return xx
+    else:
+        return [xx]
+
+def configure(conf):
+    v = conf.env
+
+    targetname = '-Vgcc_ntoarmv7le'
+
+    # Use a tool-configured OS environment variable set if available
+    environ = getattr(conf.env, 'env', os.environ)
+    if len(environ) > 0:
+        conf.find_program('qcc', environ=environ)
+    else:
+        conf.find_program('qcc')
+    conf.find_ar()
+
+    # Basic compiler executable
+    v['CC']         = to_list(v['QCC']) + [targetname, '-lang-c']
+    v['CXX']        = to_list(v['QCC']) + [targetname, '-lang-c++']
+    v['CC_NAME']    = 'qcc'
+    v['CXX_NAME']    = 'qcc'
+
+    # Target binary format
+    v['DEST_BINFMT']    = 'elf'
+
+    # Other cookie-crumbs traditionally set by the Waf compiler tool
+    v['DEST_CPU']       = 'arm'
+    v['DEST_OS']        = 'qnx'
+
+    # Source filename, destination filename
+    v['CC_SRC_F']       = []
+    v['CXX_SRC_F']      = list(v['CC_SRC_F'])
+    v['CC_TGT_F']       = ['-c', '-o']
+    v['CXX_TGT_F']      = list(v['CC_TGT_F'])
+    v['CCLNK_SRC_F']    = []
+    v['CXXLNK_SRC_F']   = list(v['CCLNK_SRC_F'])
+    v['CCLNK_TGT_F']    = ['-o']
+    v['CXXLNK_TGT_F']   = list(v['CCLNK_TGT_F'])
+
+    # Linker
+    v['LINK_CC']    = list(v['CC'])
+    v['LINK_CXX']   = list(v['CXX'])
+
+    # Search paths
+    v['CPPPATH_ST']     = '-I%s'
+    v['DEFINES_ST']     = '-D%s'
+    v['LIB_ST']         = '-l%s'
+    v['LIBPATH_ST']     = '-L%s'
+    v['STLIB_ST']       = '-l%s'
+    v['STLIBPATH_ST']   = '-L%s'
+
+    # whole program
+    v['cprogram_PATTERN']   = '%s'
+    v['cxxprogram_PATTERN'] = '%s'
+    v['SHLIB_MARKER']       = '-Bdynamic'
+    v['STLIB_MARKER']       = '-Bstatic'
+
+    # static library
+    v['cstlib_PATTERN']     = 'lib%s.a'
+    v['cxxstlib_PATTERN']   = 'lib%s.a'
+
+    # shared library
+    v['CFLAGS_cshlib']      = ['-shared']
+    v['CXXFLAGS_cxxshlib']  = ['-shared']
+    v['LINKFLAGS_cshlib']   = ['-shared']
+    v['LINKFLAGS_cxxshlib'] = ['-shared']
+    v['SONAME_ST']          = '-Wl,-h%s'
+    v['cshlib_PATTERN']     = 'lib%s.so'
+    v['cxxshlib_PATTERN']   = 'lib%s.so'
+
+    # linker options
+    v['RPATH_ST']   = '-Wl,-rpath,%s'
+
+    # Basic waf language stuff
+    conf.cc_load_tools()
+    conf.cxx_load_tools()
+    conf.cc_add_flags()
+    conf.cxx_add_flags()
+    conf.link_add_flags()

--- a/wscript
+++ b/wscript
@@ -511,6 +511,7 @@ def configure(conf):
         conf.env['LIB_PTHREAD'] = ['c']
         conf.env['LIB_DL'] = ['c']
         conf.env['LIB_RT'] = []
+        conf.env['LIB_STDC++'] = []
         conf.check_cxx( lib=['rt'], uselib_store='RT', mandatory=False )
         conf.check_cxx( lib=['socket'], uselib_store='SOCKET' )
 


### PR DESCRIPTION
This patch adds a small waf tool to add support for the QCC compiler,
which has a somewhat different command line syntax from GCC.  It also
fixes some small C++ issues which arise when trying to compile with the
QCC C++ library.

Change-Id: Id6ee4284095198bff206e45aa0e9a5fa5a2f8b74
