### PR TITLE
AlsaAdapter: Allow Only Capture or Playback

### DIFF
--- a/linux/alsa/JackAlsaAdapter.cpp
+++ b/linux/alsa/JackAlsaAdapter.cpp
@@ -89,6 +89,17 @@ namespace Jack
             }
         }
 
+        // Ignore channels for interfaces if we didn't explicitly set both
+        // playback and capture but we set at least one of them.
+        if ( !fAudioInterface.fCaptureName && fAudioInterface.fPlaybackName )
+        {
+            fCaptureChannels = 0;
+        }
+        if ( fAudioInterface.fCaptureName && !fAudioInterface.fPlaybackName )
+        {
+            fPlaybackChannels = 0;
+        }
+
         fAudioInterface.setInputs ( fCaptureChannels );
         fAudioInterface.setOutputs ( fPlaybackChannels );
     }


### PR DESCRIPTION
The current implementation of the ALSA audio adapter doesn't allow us to
only open a device as capture or playback.  It still tries to do both by
using the default card.